### PR TITLE
Specify the OpenAI version

### DIFF
--- a/01_Hello_Langchain/README.md
+++ b/01_Hello_Langchain/README.md
@@ -63,7 +63,7 @@ tags:
 ### 安装指令
 
 ```shell
-pip install langchain==0.0.235 openai
+pip install langchain==0.0.235 openai==0.28.1
 ```
 
 ### 代码

--- a/01_Hello_Langchain/README.md
+++ b/01_Hello_Langchain/README.md
@@ -63,7 +63,7 @@ tags:
 ### 安装指令
 
 ```shell
-pip install langchain==0.0.235 openai==0.28.1
+pip install langchain==0.0.235 openai==0.28.2
 ```
 
 ### 代码


### PR DESCRIPTION
OpenAI新版本更新后，与LangChain的0.0.235版本不兼容，报错。
![image](https://github.com/sugarforever/wtf-langchain/assets/640278/0c1fde51-334d-4f09-a387-b4d5b0b0061c)
