### PR TITLE
import Language

### DIFF
--- a/01_Hello_Langchain/Hello_Langchain.ipynb
+++ b/01_Hello_Langchain/Hello_Langchain.ipynb
@@ -1,26 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "authorship_tag": "ABX9TyPlnXQSa14sK6jqVM6IBQr7",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/sugarforever/wtf-langchain/blob/main/01_Hello_Langchain/Hello_Langchain.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -34,11 +18,28 @@
       },
       "outputs": [],
       "source": [
-        "!pip install langchain==0.0.235 openai"
+        "!pip install langchain==0.0.235 openai==0.28.1"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7t2nQzTEGXy1",
+        "outputId": "f0f35ba0-48e2-439c-f754-2862884ad049"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "content='Hello! How can I assist you today?' additional_kwargs={} example=False\n"
+          ]
+        }
+      ],
       "source": [
         "from langchain.chat_models import ChatOpenAI\n",
         "from langchain.schema import HumanMessage\n",
@@ -49,24 +50,23 @@
         "chat = ChatOpenAI(temperature=0)\n",
         "response = chat([ HumanMessage(content=\"Hello Langchain!\") ])\n",
         "print(response)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "7t2nQzTEGXy1",
-        "outputId": "f0f35ba0-48e2-439c-f754-2862884ad049"
-      },
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "content='Hello! How can I assist you today?' additional_kwargs={} example=False\n"
-          ]
-        }
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "authorship_tag": "ABX9TyPlnXQSa14sK6jqVM6IBQr7",
+      "include_colab_link": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/03_Data_Connections/README.md
+++ b/03_Data_Connections/README.md
@@ -86,6 +86,7 @@ split_docs = text_splitter.split_documents(docs)
 `RecursiveCharacterTextSplitter` 的 `from_language` 函数，可以根据编程语言的特性，将代码拆分为合适的文本块。代码如下：
 
 ```pyhon
+from langchain.text_splitter import Language,RecursiveCharacterTextSplitter
 PYTHON_CODE = """
 def hello_langchain():
     print("Hello, Langchain!")


### PR DESCRIPTION
![image](https://github.com/sugarforever/wtf-langchain/assets/640278/2eb8c4c6-4c55-4109-8146-152793793963)
文章在展示`langchain`的text_splitter的python分割特色时，没有引入相关包，新手可能不太了解Language模块的出处，加上了。改后的代码是：
![image](https://github.com/sugarforever/wtf-langchain/assets/640278/182d146b-4165-4224-9247-c02ddc203050)
